### PR TITLE
fix: ensure GUNICORN_WORKERS env var expands correctly at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 5000
 
 # Default 4 workers is a reasonable default for most small-to-medium apps
-CMD ["gunicorn", "app.main:app", "--bind", "0.0.0.0:5000", "--workers", "${GUNICORN_WORKERS:-4}"]
+CMD sh -c "gunicorn app.main:app -w \${GUNICORN_WORKERS:-4} -b 0.0.0.0:5000"


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR modifies the Dockerfile to ensure that ${GUNICORN_WORKERS} environment variable is expanded by the shell (sh -c) before being passed to Gunicorn.

Without this change, Gunicorn fails to parse ${GUNICORN_WORKERS:-4} as a valid integer, leading to runtime errors.

This fixes startup issues in containerized environments like ECS or Kubernetes.

---

## 🛠 Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor (no functional change)
- [ ] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [ ] ⚙️ Build/deployment changes
