### PR TITLE
chore: build and push docker image only on main branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: test-compose
+    if: github.event_name == 'push'
     permissions:
       packages: write
       contents: write


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

This PR updates the CI workflow to build and push the Docker image only on push events to the main branch.
Pull requests now run only linting and testing jobs without triggering builds or deployments, ensuring faster feedback cycles and preventing unnecessary image builds.

Updated: .github/workflows/ci.yml

Added conditional check if: github.event_name == 'push' to the build-and-push job.

---

## 🛠 Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor (no functional change)
- [ ] 🧹 Code quality improvement (linting, format, CI)
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🛡️ Test coverage improvement
- [ ] ⚙️ Build/deployment changes
