### PR TITLE
Ci/add image scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,13 @@ jobs:
           docker buildx build --push \
             --tag $IMAGE_NAME:${{ env.VERSION }} .
 
+      - name: Scan Docker image with Trivy
+        uses: aquasecurity/trivy-action@v0.16.1
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          format: table
+          severity: CRITICAL,HIGH
+
       - name: Dispatch Update Config Repo
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
# 📋 Pull Request

## 📄 Description

> This PR enhances the GitHub Actions workflow by adding a security scan step for the Docker image using [Trivy](https://github.com/aquasecurity/trivy).

Changes Made
- Added aquasecurity/trivy-action to the build-and-push job.
- The step scans the built Docker image for vulnerabilities with severity HIGH and CRITICAL.
- Scan occurs after the image is built and pushed to GHCR.
